### PR TITLE
Update HTTPServer example to bind to 0.0.0.0 in order to make demoing…

### DIFF
--- a/HTTPServer/src/main/java/com/ociweb/oe/foglight/api/HTTPServer.java
+++ b/HTTPServer/src/main/java/com/ociweb/oe/foglight/api/HTTPServer.java
@@ -21,7 +21,7 @@ public class HTTPServer implements FogApp
     @Override
     public void declareConnections(Hardware c) {
         
-		c.enableServer(false, 8088);    	
+		c.enableServer(false, false, "0.0.0.0", 8088);    	
 		emptyResponseRouteId = c.registerRoute("/testpageA?arg=#{myarg}", cookieHeader);
 		smallResponseRouteId = c.registerRoute("/testpageB");
 		largeResponseRouteId = c.registerRoute("/testpageC", cookieHeader);


### PR DESCRIPTION
This PR modifies the HTTPServer example to bind to the `0.0.0.0` interface in order to make invocations via `localhost:8088` possible. This simplified demoes and testing, making it slightly more intuitive and predictable (originally modified to support batch load testing).